### PR TITLE
allowInterop() fix + include the whole FCM payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+- The whole FCM payload can now be retrieved `notification, data, from` instead of only the `notification` object.
+- Fixes for sending Dart function to JS
+
 ## 1.1.0
 
 - Fixing multiple issues.

--- a/lib/src/fcm_interface.dart
+++ b/lib/src/fcm_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:js';
+
 import 'package:firebase_cloud_messaging_interop/src/fcm_interop.dart';
 import 'package:firebase_cloud_messaging_interop/src/js_to_dart_helper.dart';
 
@@ -28,9 +30,9 @@ class FCM {
   void onTokenRefresh(Function() callBack) =>
       _messaging.onTokenRefresh(callBack);
 
-  /// Adding a callback allowing to retrieve the notification data ([Notification]).
-  void onMessage(Function(Notification notification) callBack) =>
-      _messaging.onMessage((Message e) => callBack((e.notification)));
+  /// Adding a callback allowing to retrieve the FCM payload
+  void onMessage(Function(Map message) callBack) =>
+      _messaging.onMessage(allowInterop((Map e) => callBack((toDartMap(e)))));
 
   /// Delete the current FCM token.
   Future<bool> deleteToken(String token) =>

--- a/lib/src/fcm_interop.dart
+++ b/lib/src/fcm_interop.dart
@@ -17,7 +17,7 @@ class Firebase {
 
 typedef FnStr = Function(String str);
 typedef FnCallback = Function(Function callBack);
-typedef FnCallbackMessage = Function(Function(Message message) callBack);
+typedef FnCallbackMessage = Function(Function(Map message) callBack);
 typedef Promise<T> FnReturningPromise<T>([arg]);
 
 @JS()

--- a/lib/src/js_to_dart_helper.dart
+++ b/lib/src/js_to_dart_helper.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:js';
 
 import 'package:firebase_cloud_messaging_interop/src/fcm_interop.dart';
@@ -11,4 +12,10 @@ Future futureFromPromise<T>(Promise<T> p) {
       allowInterop(completer.complete), allowInterop(completer.completeError));
 
   return completer.future;
+}
+
+Map toDartMap(jsObject) {
+  String stringJSObject = context['JSON'].callMethod('stringify', [jsObject]);
+  if (stringJSObject == null || stringJSObject.isEmpty) return null;
+  return jsonDecode(stringJSObject);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_cloud_messaging_interop
 description: A dart plugin to use the Firebase Cloud Messaging Api (JS). You can retrieve the user's FCM token, delete it, access the notification data, ...
 
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/GaspardMerten/Firebase-Cloud-Messaging-Interop
 homepage: https://github.com/GaspardMerten/Firebase-Cloud-Messaging-Interop
 author: Gaspard Merten <gaspard.mp.work@gmail.com>


### PR DESCRIPTION
While implementing this package in a Flutter Web project the notification work fine in background mode, but not foreground. I had to make the below changes to get the FCM payload in Dart.

### Fixed items
- using `allowInterop()` when passing the `onMessage` callback.  Before adding this, the `firebasejs` didn't receive a function, instead received an object.
- converting the `JSObject` received from the callback to a Dart `Map` since the callback when printed would print in Chrome console `[Object object]`

### Added
- The whole FCM payload is now sent to the callback instead of `notification` only.